### PR TITLE
feat: can config automatic validation

### DIFF
--- a/config/config.default.ts
+++ b/config/config.default.ts
@@ -5,6 +5,7 @@ export default () => {
 
   config.typeGraphQL = {
     router: '/graphql',
+    validate: true,
     globalMiddlewares: [],
   }
 

--- a/lib/GraphQLServer.ts
+++ b/lib/GraphQLServer.ts
@@ -18,6 +18,7 @@ interface ScalarsMapItem {
 
 interface GraphQLConfig {
   router: string
+  validate?: boolean
   globalMiddlewares?: Array<MiddlewareFn<any>>
   scalarsMap?: ScalarsMapItem[]
   dateScalarMode?: 'isoDate' | 'timestamp'
@@ -161,6 +162,7 @@ export default class GraphQLServer {
         dateScalarMode: 'isoDate',
         scalarsMap: [...defaultScalarMap, ...scalarsMap],
         emitSchemaFile: true,
+        validate: this.graphqlConfig.validate || true,
         globalMiddlewares: this.graphqlConfig.globalMiddlewares || [],
         container: () => new CustomContainer(),
       })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,6 +12,7 @@ declare module 'egg' {
   interface EggAppConfig {
     typeGraphQL: {
       router: string
+      validate?: boolean;
       globalMiddlewares?: MiddlewareFn<any>[]
       scalarsMap?: scalarsMapItem[]
       dateScalarMode?: 'isoDate' | 'timestamp'


### PR DESCRIPTION
可以配置在没有使用任何 `class-validator` 装饰器时，控制台不会提示

> No metadata found. There is more than once class-validator version installed probably. You need to flatten your dependencies.

https://github.com/MichalLytek/type-graphql/issues/150#issuecomment-420181526