### PR TITLE
fix: remove wrong default config of validation

### DIFF
--- a/lib/GraphQLServer.ts
+++ b/lib/GraphQLServer.ts
@@ -143,7 +143,7 @@ export default class GraphQLServer {
         dateScalarMode: 'isoDate',
         scalarsMap: [ ...defaultScalarMap, ...scalarsMap ],
         emitSchemaFile: true,
-        validate: this.graphqlConfig.validate || true,
+        validate: this.graphqlConfig.validate,
         globalMiddlewares: this.graphqlConfig.globalMiddlewares || [],
         container: Container,
       });


### PR DESCRIPTION
`validate: this.graphqlConfig.validate || true` is always true as there has a default value of `validate` in `graphqlConfig` 😂 

Sorry for my carelessness.